### PR TITLE
Override the name of the issuer wallet

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -12,6 +12,7 @@ issuers:
       sign_target: false
 
     wallet:
+      name: ${POSTGRESQL_WALLET_NAME:-onbis_issuer}
       seed: $WALLET_SEED_ONBIS
       type: $WALLET_TYPE
       params:


### PR DESCRIPTION
- Allow it to be configured.
- There is an issue with the default wallet names when using postgres storage.
  - The code thinks it has created the database and then fails to connect to the database to create the schema.
  - Simple fix is to set the name of the wallet in services.yml